### PR TITLE
Add dark-light theme

### DIFF
--- a/QuickLookAddict/themes/dark-light.css
+++ b/QuickLookAddict/themes/dark-light.css
@@ -1,0 +1,126 @@
+:root {
+  --index-number-text: #000000;
+  --time-text: #0068D9;
+  --subtitle-text: #272727;
+  --info-text: #000000;
+  --border: #d4d4d4;
+  --green-color: #35b047;
+  --red-color: #FF3A30;
+  --bg-color: #ffffff;
+}
+
+  /* infoBar */
+.infoBar {
+  color: var(--info-text);
+  font-family: Menlo, monospace;
+  font-size: 10px;
+  padding: 20px;
+  margin: 0;
+  list-style: none;
+}
+
+ul.infoBar > li {
+  display: inline-block;
+  padding-right: 30px;
+  padding-left: 40px;
+}
+
+.right {
+  float: right;
+}
+
+.green {
+  color: var(--green-color);
+}
+
+.red {
+  color: var(--red-color);
+}
+
+body {
+    /* top | right | bottom | left */
+  margin: 2ch 0 0 0;
+  font-family: Helvetica, sans-serif;
+  color: var(--bg-color);
+  background-color: var(--bg-color);
+}
+
+table {
+  margin-top: 2ch;
+}
+
+table td {
+  border: 1px solid var(--border);
+}
+
+table tr:first-child td {
+  border-top: 0;
+}
+
+table tr td:first-child {
+  border-left: 0;
+}
+
+table tr:last-child td {
+  border-bottom: 0;
+}
+
+table tr td:last-child {
+  border-right: 0;
+}
+
+table tr td:first-child + td {
+  border-collapse: collapse;
+  padding-top: 2ch;
+  padding-bottom: 2ch;
+  padding-left: 2ch;
+  padding-right: 2ch;
+  width: 12ch;
+}
+
+table tr td:first-child + td + td {
+  border-collapse: collapse;
+  vertical-align: bottom;
+  text-align: center;
+  padding-left: 1ch;
+  padding-top: 2ch;
+  padding-bottom: 2ch;
+}
+
+.id {
+  font-family: Menlo, monospace;
+  font-weight: bold;
+  vertical-align: middle;
+  text-align: center;
+  color: var(--index-number-text);
+  border-color: var(--border);
+}
+
+.time {
+  border-collapse: collapse;
+  font-family: Menlo, monospace;
+  font-size: 12px;
+  color: var(--time-text);
+  border-color: var(--border);
+}
+
+.sub {
+  line-height: 1.3em;
+  font-family: Helvetica, sans-serif;
+  color: var(--subtitle-text);
+  border-collapse: collapse;
+  font-size: 15px;
+  border-color: var(--border);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --index-number-text: #DCDCDC;
+    --time-text: #419CFF;
+    --subtitle-text: #DCDCDC;
+    --info-text: #ffffff;
+    --border: #343434;
+    --green-color: #62BA46;
+    --red-color: #FE5258;
+    --bg-color: #1e1e1e;
+  }


### PR DESCRIPTION
Modern looking theme. Automatically switches between dark / light mode according to the system preference.
you can make this default theme if you want.
![dark-light](https://user-images.githubusercontent.com/36481442/68552550-40780880-0429-11ea-967d-db2f45b80024.gif)

# dark:
<img width="806" alt="dark" src="https://user-images.githubusercontent.com/36481442/68552606-d2801100-0429-11ea-88ea-382e29eaf325.png">

# light:
<img width="806" alt="light" src="https://user-images.githubusercontent.com/36481442/68552620-ec215880-0429-11ea-8d46-981fc3f8cbdd.png">
