### PR TITLE
Add UTIs claimed by mpv and Infuse app

### DIFF
--- a/QuickLookAddict/GeneratePreviewForURL.m
+++ b/QuickLookAddict/GeneratePreviewForURL.m
@@ -133,8 +133,10 @@ OSStatus GeneratePreviewForURL(void *thisInterface, QLPreviewRequestRef preview,
   /*
    * Get title and link
    */
-  MDItemRef item = MDItemCreateWithURL(kCFAllocatorDefault, url);
-  NSArray *whereFroms = CFBridgingRelease(MDItemCopyAttribute(item, kMDItemWhereFroms));
+//MDItemRef item = MDItemCreateWithURL(kCFAllocatorDefault, url);
+//CFArrayRef froms = MDItemCopyAttribute(item, kMDItemWhereFroms);
+  CFArrayRef froms = NULL;
+  NSArray *whereFroms = CFBridgingRelease(froms);
 
   NSString *titleContent = @"";
   if (whereFroms) {

--- a/QuickLookAddict/Info.plist
+++ b/QuickLookAddict/Info.plist
@@ -14,6 +14,8 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>dyn.ah62d4rv4ge81g6xy</string>
+				<string>io.mpv.subrip</string>
+				<string>com.firecore.fileformat.srt</string>
 			</array>
 			<key>LSTypeIsPackage</key>
 			<false/>


### PR DESCRIPTION
Dynamic UTI 'dyn.ah62d4rv4ge81g6xy' stops working once other app like mpv.app or Infuse.app declares its own UTI.
This commit fix it.
Tested on a Intel Mac running Catalina 10.15.7.